### PR TITLE
MutableTree: Refactor support for versions

### DIFF
--- a/nodedb.go
+++ b/nodedb.go
@@ -329,6 +329,10 @@ func (ndb *nodeDB) Commit() {
 	ndb.batch = ndb.db.NewBatch()
 }
 
+func (ndb *nodeDB) hasRoot(version int64) bool {
+	return ndb.db.Has(ndb.rootKey(version))
+}
+
 func (ndb *nodeDB) getRoot(version int64) []byte {
 	return ndb.db.Get(ndb.rootKey(version))
 }

--- a/proof_range.go
+++ b/proof_range.go
@@ -472,7 +472,7 @@ func (t *ImmutableTree) GetRangeWithProof(startKey []byte, endKey []byte, limit 
 // GetVersionedWithProof gets the value under the key at the specified version
 // if it exists, or returns nil.
 func (tree *MutableTree) GetVersionedWithProof(key []byte, version int64) ([]byte, *RangeProof, error) {
-	if tree.versions[version] {
+	if tree.VersionExists(version) {
 		t, err := tree.GetImmutable(version)
 		if err != nil {
 			return nil, nil, err
@@ -487,7 +487,7 @@ func (tree *MutableTree) GetVersionedWithProof(key []byte, version int64) ([]byt
 func (tree *MutableTree) GetVersionedRangeWithProof(startKey, endKey []byte, limit int, version int64) (
 	keys, values [][]byte, proof *RangeProof, err error) {
 
-	if tree.versions[version] {
+	if tree.VersionExists(version) {
 		t, err := tree.GetImmutable(version)
 		if err != nil {
 			return nil, nil, nil, err

--- a/tree_test.go
+++ b/tree_test.go
@@ -71,7 +71,6 @@ func TestVersionedRandomTree(t *testing.T) {
 		tree.DeleteVersion(int64(i))
 	}
 
-	require.Len(tree.versions, 1, "tree must have one version left")
 	tr, err := tree.GetImmutable(int64(versions))
 	require.NoError(err, "GetImmutable should not error for version %d", versions)
 	require.Equal(tr.root, tree.root)
@@ -312,7 +311,6 @@ func TestVersionedTree(t *testing.T) {
 	_, err = tree.Load()
 	require.NoError(err)
 
-	require.Len(tree.versions, 2, "wrong number of versions")
 	require.EqualValues(v2, tree.Version())
 
 	// -----1-----


### PR DESCRIPTION
LoadVersionFast is changed so that passing a zero version works
correctly by obtaining the latest version via the nodedb.

Load is changed so that it uses LoadVersionFast to avoid traversing all
the versions in the database. To avoid issues with tree.versions, that
internal bitmap is removed and replaced with a hasRoot query against the
nodedb.