### PR TITLE
MutableTree: Add `EldestVersion`

### DIFF
--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -43,6 +43,11 @@ func (tree *MutableTree) VersionExists(version int64) bool {
 	return tree.ndb.hasRoot(version)
 }
 
+// EldestVersion returns the eldest version, or `-1` iff no versions exist.
+func (tree *MutableTree) EldestVersion() int64 {
+	return tree.ndb.getEldestVersion()
+}
+
 // Hash returns the hash of the latest saved version of the tree, as returned
 // by SaveVersion. If no versions have been saved, Hash returns nil.
 func (tree *MutableTree) Hash() []byte {

--- a/nodedb.go
+++ b/nodedb.go
@@ -244,6 +244,25 @@ func (ndb *nodeDB) updateLatestVersion(version int64) {
 	}
 }
 
+func (ndb *nodeDB) getEldestVersion() int64 {
+	// This is used infrequently enough that it likely doesn't need
+	// to be cached.
+	itr := ndb.db.Iterator(
+		rootKeyFormat.Key(0),
+		rootKeyFormat.Key(1<<63-1),
+	)
+	defer itr.Close()
+
+	if itr.Valid() {
+		var eversion int64
+		k := itr.Key()
+		rootKeyFormat.Scan(k, &eversion)
+		return eversion
+	}
+
+	return -1
+}
+
 func (ndb *nodeDB) getPreviousVersion(version int64) int64 {
 	itr := ndb.db.ReverseIterator(
 		rootKeyFormat.Key(version-1),

--- a/tree_test.go
+++ b/tree_test.go
@@ -51,6 +51,8 @@ func TestVersionedRandomTree(t *testing.T) {
 	versions := 50
 	keysPerVersion := 30
 
+	require.EqualValues(-1, tree.EldestVersion(), "eldest version when empty tree")
+
 	// Create a tree of size 1000 with 100 versions.
 	for i := 1; i <= versions; i++ {
 		for j := 0; j < keysPerVersion; j++ {
@@ -69,6 +71,7 @@ func TestVersionedRandomTree(t *testing.T) {
 
 	for i := 1; i < versions; i++ {
 		tree.DeleteVersion(int64(i))
+		require.EqualValues(i+1, tree.EldestVersion(), "wrong eldest version")
 	}
 
 	tr, err := tree.GetImmutable(int64(versions))


### PR DESCRIPTION
Certain use cases require being able to fetch the eldest persisted
version to be efficient.