### PR TITLE
nodeDB: `getLatestVersion()` should always query the DB

### DIFF
--- a/nodedb.go
+++ b/nodedb.go
@@ -232,9 +232,12 @@ func (ndb *nodeDB) rootKey(version int64) []byte {
 }
 
 func (ndb *nodeDB) getLatestVersion() int64 {
-	if ndb.latestVersion == 0 {
-		ndb.latestVersion = ndb.getPreviousVersion(1<<63 - 1)
-	}
+	// Every single case where this is called, the overhead of hitting up
+	// the database will be masked by having to do lots of other DB
+	// operations.
+
+	ndb.latestVersion = ndb.getPreviousVersion(1<<63 - 1)
+
 	return ndb.latestVersion
 }
 


### PR DESCRIPTION
For our somewhat unconventional ABCI mux use case where we have two
tree instances backed by the same DB, having `getLatestVersion()` always
query the backing DB serves to keep the internal state from getting out
of sync.